### PR TITLE
Fixed encoding error

### DIFF
--- a/lib/localch_i18n/translations.rb
+++ b/lib/localch_i18n/translations.rb
@@ -59,8 +59,9 @@ module LocalchI18n
     
     def download(url, destination_file)
       puts "Download '#{url}' to '#{destination_file}'"
+      doc_data = open(url).read.force_encoding('UTF-8')
       File.open(destination_file, 'w') do |dst|
-        dst.write(open(url).read)
+        dst.write(doc_data)
       end
     end
     


### PR DESCRIPTION
Google docs return ASCII-8BIT.

Without force_encoding i get following error:
"\xC3" from ASCII-8BIT to UTF-8
