### PR TITLE
Don't downcase locale names

### DIFF
--- a/lib/localch_i18n/translation_file_export.rb
+++ b/lib/localch_i18n/translation_file_export.rb
@@ -8,7 +8,7 @@ module LocalchI18n
       @source_file = source_file
       
       @output_file = File.join(output_dir, source_file.gsub('.yml', '.csv'))
-      @locales = locales.map {|l| l.to_s.downcase }
+      @locales = locales.map {|l| l.to_s }
       
       @translations = {}
     end


### PR DESCRIPTION
Exporting locales with valid uppercase local names (pt-BR) don't work with downcase
