### PR TITLE
Skip lines with an empty "key"

### DIFF
--- a/lib/localch_i18n/csv_to_yaml.rb
+++ b/lib/localch_i18n/csv_to_yaml.rb
@@ -42,6 +42,7 @@ module LocalchI18n
 
     def process_row(row_hash)
       key = row_hash.delete('key')
+      return unless key
 
       key_elements = key.split('.')
       @locales.each do |locale|

--- a/test/unit/csv_to_yaml_test.rb
+++ b/test/unit/csv_to_yaml_test.rb
@@ -36,6 +36,17 @@ module UnitTests
       assert_equal 'Welcome', translations['en']['homepage']['welcome']
     end
 
+    def test_empty_row
+      row1 = {'key' => 'homepage.meta.title', 'en' => 'Phonebook of Switzerland', 'de' => 'Telefonbuch der Schweiz'}
+      row2 = {'key' => nil, 'en' => 'Welcome', 'de' => 'Willkommen'}
+      @csv_to_yaml.process_row(row1)
+      @csv_to_yaml.process_row(row2)
+
+      translations = @csv_to_yaml.translations
+      assert_equal 'Telefonbuch der Schweiz', translations['de']['homepage']['meta']['title']
+      assert_equal 'Phonebook of Switzerland', translations['en']['homepage']['meta']['title']
+    end
+
     def test_row_containing_non_locale_columns
       row = {'key' => 'homepage.title', 'en' => "We are the Phonebook", 'de' => 'Test DE', 'comment' => "Test comment"}
       @csv_to_yaml.process_row(row)


### PR DESCRIPTION
Fixes the `undefined method 'split' for nil:NilClass` when loading documents with an empty "key". These lines are simply ignored. The tests do not use `assert_nothing_raised` - hope this is okay like that.

Related to #7 and #8
