### PR TITLE
add encoding: utf-8 To gemspec

### DIFF
--- a/i18n-docs.gemspec
+++ b/i18n-docs.gemspec
@@ -1,3 +1,4 @@
+# encoding: utf-8
 Gem::Specification.new do |s|
   s.name        = 'i18n-docs'
   s.version     = '0.0.7'


### PR DESCRIPTION
```
There was a SyntaxError while loading i18n-docs.gemspec: 
/Users/hiphapis/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/bundler/gems/i18n-docs-c8983dc7ca8a/i18n-docs.gemspec:7: invalid multibyte char (US-ASCII)
/Users/hiphapis/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/bundler/gems/i18n-docs-c8983dc7ca8a/i18n-docs.gemspec:7: invalid multibyte char (US-ASCII)
/Users/hiphapis/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/bundler/gems/i18n-docs-c8983dc7ca8a/i18n-docs.gemspec:7: syntax error, unexpected end-of-input, expecting ']'
..., "Jeremy Seitz", "Eduard Schäli", "Robin Wunderlin", "Este...
```

so i added encoding: utf-8
